### PR TITLE
Added EMS Success / Fail Responses to Application Processing

### DIFF
--- a/src/main/resources/openapi/EMSIntegrationAPIs.yaml
+++ b/src/main/resources/openapi/EMSIntegrationAPIs.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: EROP EMS Integration APIs for Postal and Proxy Vote Applications (OAVA)
-  version: 1.1.1
+  version: 1.2.0
   description: |
     This specification is for an API hosted by EROP for EMS clients to fetch
     details of Postal Vote and Proxy Vote applications made by the public.
@@ -40,7 +40,7 @@ servers:
 paths:
   /postalvotes:
     get:
-      summary: -|
+      summary:
         For retrieving approved and rejected Postal Vote applications after determination within the EROP
       tags:
         - Postal Vote related endpoints
@@ -103,12 +103,12 @@ paths:
         name: id
         in: path
         required: true
-    delete:
-      summary: -|
+    post:
+      summary: 
         Confirmation from EMSs that the Postal Vote application has been received and should be 
         removed from the queue. The EMS can indicate if processing was successful or failed to update the elector's
-        details. Error responses will alert the determining ERO officer of the failure.
-      operationId: delete-postal-votes-id
+        details - or any other failure in processing. Error responses will alert the determining ERO officer of the failure.
+      operationId: post-postal-votes-id
       requestBody:
         $ref: '#/components/requestBodies/EMSApplicationResponse'
       responses:
@@ -118,7 +118,7 @@ paths:
           description: Not Found
       tags:
         - Postal Votes
-      description: |-
+      description:
         Postal vote applications acknowledged will be removed from the queue immediately, 
 
         If the specified ID does not exist, or belongs to a Postal Vote application that is not for the currently connected ERO, 
@@ -132,7 +132,36 @@ paths:
           integration.request.header.client-cert-serial: context.authorizer.client-cert-serial
         connectionType: VPC_LINK
         connectionId: '${vpc_connection_id}'
-        httpMethod: GET
+        httpMethod: POST
+    delete:
+      summary: 
+        Deprecated, please use POST endpoint to return success and failure responses. 
+        Confirmation from EMSs that the Postal Vote application has been received and should be 
+        removed from the queue.
+      operationId: delete-postal-votes-id
+      deprecated: true
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+      tags:
+        - Postal Votes
+      description:
+        Postal vote applications acknowledged will be removed from the queue immediately, 
+
+        If the specified ID does not exist, or belongs to a Postal Vote application that is not for the currently connected ERO, 
+        then the response will be an “HTTP 404 Not Found” response.
+      security:
+        - emsCertificateLambdaAuthorizer: []
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/postalvotes/{id}'
+        requestParameters:
+          integration.request.header.client-cert-serial: context.authorizer.client-cert-serial
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: DELETE        
   /proxyvotes:
     get:
       summary: For retrieving approved and rejected Proxy Vote applications after determination within the EROP
@@ -167,12 +196,12 @@ paths:
         name: id
         in: path
         required: true
-    delete:
-      summary: -|
+    post:
+      summary:
         Confirmation from EMSs that the Proxy Vote application has been received and should be 
         removed from the queue. The EMS can indicate if processing was successful or failed to update the elector's
-        details. Error responses will alert the determining ERO officer of the failure.
-      operationId: delete-proxy-votes-id
+        details - or any other failure in processing. Error responses will alert the determining ERO officer of the failure.
+      operationId: post-proxy-votes-id
       requestBody:
         $ref: '#/components/requestBodies/EMSApplicationResponse'
       responses:
@@ -182,7 +211,7 @@ paths:
           description: Not Found
       tags:
         - Proxy Vote related endpoints
-      description: |-
+      description:
         Proxy vote applications that are acknowledged in this way will be removed from the queue immediately, and marked that the EMS has successfully recieved and committed the application within their corresponding EMS.
 
         If the specified ID does not exist, or belongs to a Proxy Vote application that is not for the currently connected ERO, then the response will be an “HTTP 404 Not Found” response.
@@ -195,10 +224,39 @@ paths:
           integration.request.header.client-cert-serial: context.authorizer.client-cert-serial
         connectionType: VPC_LINK
         connectionId: '${vpc_connection_id}'
-        httpMethod: GET
+        httpMethod: POST
+    delete:
+      summary:
+        Deprecated, please use POST endpoint to return success and failure responses. 
+        Confirmation from EMSs that the Postal Vote application has been received and should be 
+        removed from the queue.
+      operationId: delete-proxy-votes-id
+      deprecated: true
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+      tags:
+        - Proxy Vote related endpoints
+      description:
+        Proxy vote applications that are acknowledged in this way will be removed from the queue immediately, and marked that the EMS has successfully recieved and committed the application within their corresponding EMS.
+
+        If the specified ID does not exist, or belongs to a Proxy Vote application that is not for the currently connected ERO, then the response will be an “HTTP 404 Not Found” response.
+      security:
+        - emsCertificateLambdaAuthorizer: [ ]
+      x-amazon-apigateway-integration:
+        type: HTTP_PROXY
+        uri: '${base_uri}/proxyvotes/{id}'
+        requestParameters:
+          integration.request.header.client-cert-serial: context.authorizer.client-cert-serial
+        connectionType: VPC_LINK
+        connectionId: '${vpc_connection_id}'
+        httpMethod: DELETE        
 components:
   schemas:
     PostalVote:
+      title: Proxy Vote
       type: object
       properties:
         id:
@@ -404,6 +462,7 @@ components:
         - authorisingStaffId
         - detail
     ProxyVote:
+      title: Postal Vote
       type: object
       properties:
         id:
@@ -463,7 +522,7 @@ components:
               type: string
               maxLength: 45
               example: 127.0.0.1
-              description: |
+              description:
                 the IP address from which the application was received (digital applications only)
             lang:
               $ref: '#/components/schemas/ApplicationLanguage'
@@ -532,12 +591,12 @@ components:
             proxyln:
               type: string
               maxLength: 35
-              description: |
+              description:
                 last name of the chosen proxy
             proxyfamilyrelationship:
               type: string
               maxLength: 500
-              description: |
+              description:
                 (optional) the family relationship (if any) of the chosen proxy. The question to users is “What is your proxy’s relationship to you?”
             proxyproperty:
               type: string
@@ -572,25 +631,25 @@ components:
               maxLength: 255
             proxyreason:
               type: string
-              description: |-
+              description:
                 a free-form text value containing the applicant’s response to the question “please explain why you are not able to go to your polling station on polling day” for the primary form variant or other text for other form variants (max 500 utf-8 chars)
                 All proxy vote forms, including variants which require supporting documentation, will be handled in the EROP. The ERO user working in that application will review the documentation as required and only accepted applications will be seen on this API. The supporting documentation, if any, will not be sent through here. The field “proxyreason” will contain details for other form variants and may have been filled in by an ERO user.
               maxLength: 500
             signature:
               type: string
               format: byte
-              description: |
+              description:
                 Base64 encoded signature image of the applicant’s signature, in Base64 encoded PNG format. The image will be 1050 pixels wide and 300 pixels high, corresponding to a scan of the paper forms at 300 dpi. The image will be black and white only. The image will be cropped so that the signature fills the box with a small white margin. The data length is usually under 30KB.
             signatureWaived:
               type: boolean
               default: false
-              description: |
+              description:
                 Where an Elector has been granted a signature waiver. If 'true', then no signature will be provided and a signatureWaivedReason will be supplied.
             signatureWaivedReason:
               type: string
               maxLength: 250
               default: false
-              description: |
+              description:
                 Where an Elector has been granted a signature waiver, this field will contain a descriptin of the reason for the waiver.
             proxyVoteUntilFurtherNotice:
               type: boolean
@@ -598,19 +657,19 @@ components:
             proxyVoteForSingleDate:
               type: string
               format: date
-              description: |
+              description:
                 If proxy application is for a single date
                 In ISO8601 date format '2022-08-02'
             proxyVoteStartDate:
               type: string
               format: date
-              description:  |
+              description:
                 If set, the elector wishes to vote by proxy for the period defined by the two dates. If present, then proxyVoteEndDate must also be present
                 In ISO8601 date format '2022-08-02'
             proxyVoteEndDate:
               type: string
               format: date
-              description:  |
+              description:
                 If set, the elector wishes to vote by proxy for the period defined by the two dates. If present, then proxyVoteStartDate must also be present
                 In ISO8601 date format '2022-08-02'
       required:
@@ -622,14 +681,14 @@ components:
         - authorisingStaffId
         - detail
     ApplicationStatus:
-      title: ApplicationStatus
+      title: Application Status
       description: Enum indicating if an application is approved or rejected.
       type: string
       enum:
         - approved
         - rejected
     ApplicationLanguage:
-      title: ApplicationLanguage
+      title: Application Language
       description: Enum indicating “en” or “cy” according to which language the applicant used
       type: string
       enum:
@@ -669,7 +728,7 @@ components:
           type: string
           description: Detailed description of processing status. 
     EMSApplicationStatus:
-      title: EMSApplicationStatus
+      title: EMS Application Status
       description: Indicates if the EMS succeeded or failed updating the application's Elector details.
       type: string
       default: success

--- a/src/main/resources/openapi/EMSIntegrationAPIs.yaml
+++ b/src/main/resources/openapi/EMSIntegrationAPIs.yaml
@@ -105,9 +105,12 @@ paths:
         required: true
     delete:
       summary: -|
-        Confirmation from EMS systems that a Postal Vote application has been received and processed.
-        Successful responses will indicate the application will be removed from the LA/VJB/EMS's queue.
+        Confirmation from EMSs that the Postal Vote application has been received and should be 
+        removed from the queue. The EMS can indicate if processing was successful or failed to update the elector's
+        details. Error responses will alert the determining ERO officer of the failure.
       operationId: delete-postal-votes-id
+      requestBody:
+        $ref: '#/components/requestBodies/EMSApplicationResponse'
       responses:
         '204':
           description: No Content
@@ -116,9 +119,10 @@ paths:
       tags:
         - Postal Votes
       description: |-
-        Postal vote applications that are acknowledged in this way will be removed from the queue immediately, and marked that the EMS has successfully recieved and committed the application within their corresponding EMS.
+        Postal vote applications acknowledged will be removed from the queue immediately, 
 
-        If the specified ID does not exist, or belongs to a Postal Vote application that is not for the currently connected ERO, then the response will be an “HTTP 404 Not Found” response.
+        If the specified ID does not exist, or belongs to a Postal Vote application that is not for the currently connected ERO, 
+        then the response will be an “HTTP 404 Not Found” response.
       security:
         - emsCertificateLambdaAuthorizer: []
       x-amazon-apigateway-integration:
@@ -164,8 +168,13 @@ paths:
         in: path
         required: true
     delete:
-      summary: For marking a single Proxy Vote application as received
+      summary: -|
+        Confirmation from EMSs that the Proxy Vote application has been received and should be 
+        removed from the queue. The EMS can indicate if processing was successful or failed to update the elector's
+        details. Error responses will alert the determining ERO officer of the failure.
       operationId: delete-proxy-votes-id
+      requestBody:
+        $ref: '#/components/requestBodies/EMSApplicationResponse'
       responses:
         '204':
           description: No Content
@@ -646,6 +655,27 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PostalVote'
+    EMSApplicationResponse:
+      title: EMS Application Processing Response
+      description: The EMSs response indicating success or failure processing the application.
+      type: object
+      properties:
+        status:
+          $ref: '#/components/schemas/EMSApplicationStatus'
+        message:
+          type: string
+          description: ERO friendly summary of processing status. Primarily intended for error conditions.
+        details:
+          type: string
+          description: Detailed description of processing status. 
+    EMSApplicationStatus:
+      title: EMSApplicationStatus
+      description: Indicates if the EMS succeeded or failed updating the application's Elector details.
+      type: string
+      default: success
+      enum:
+        - success
+        - failure
   responses:
     PostalVoteApplications:
       description: Determined Postal Vote applications
@@ -659,6 +689,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/ProxyVoteApplications'
+  requestBodies:
+    EMSApplicationResponse:
+      description: The EMSs response indicating success or failure processing the application.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EMSApplicationResponse'
   securitySchemes:
     emsCertificateLambdaAuthorizer:
       type: 'apiKey'


### PR DESCRIPTION
Proposed addition to EMS responses to consuming Postal and Proxy applications from EROP.
This addition allows EMSs to indicate whether the application has been successful processed or has failed.