### PR TITLE
[EIP1-6836] Increase rejection notes for other language initially missed

### DIFF
--- a/src/main/resources/db/changelog/create/0012_EIP1-6836_modify_remaining_rejection_reasons.xml
+++ b/src/main/resources/db/changelog/create/0012_EIP1-6836_modify_remaining_rejection_reasons.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="stephen.penney@softwire.com" id="0012_EIP1-6836_modify_rejection_reasons" context="ddl">
+        <modifyDataType tableName="postal_vote_application" columnName="welsh_rejection_notes" newDataType="varchar(4000)"/>
+        <modifyDataType tableName="proxy_vote_application" columnName="english_rejection_notes" newDataType="varchar(4000)"/>
+
+        <rollback>
+            <modifyDataType tableName="postal_vote_application" columnName="welsh_rejection_notes" newDataType="varchar(1024)"/>
+            <modifyDataType tableName="proxy_vote_application" columnName="english_rejection_notes" newDataType="varchar(1024)"/>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -21,3 +21,5 @@ databaseChangeLog:
       file: /db/changelog/create/0010_EIP1-6671_add_rejection_reasons.xml
   - include:
       file: /db/changelog/create/0011_EIP1-6891_modify_rejection_reasons.xml
+  - include:
+      file: /db/changelog/create/0012_EIP1-6836_modify_remaining_rejection_reasons.xml


### PR DESCRIPTION
Migration 11 updated length for `<english|welsh>_rejection_notes` but a duplication mistake meant it was only one language per application process rather than both. This new migration increases the corresponding length for the other language.