### PR TITLE
EIP1-7400 Add index on date_created to application tables to fix issue

### DIFF
--- a/src/main/resources/db/changelog/create/0013_EIP1-7400_add_index_on_date_created.xml
+++ b/src/main/resources/db/changelog/create/0013_EIP1-7400_add_index_on_date_created.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="stephen.penney@softwire.com" id="0013_EIP1-7400_add_index_on_date_created" context="ddl">
+        <createIndex tableName="postal_vote_application" indexName="postal_vote_application_date_created_idx">
+            <column name="date_created"/>
+        </createIndex>
+        <createIndex tableName="proxy_vote_application" indexName="proxy_vote_application_date_created_idx">
+            <column name="date_created"/>
+        </createIndex>
+
+        <rollback>
+            <dropIndex tableName="postal_vote_application" indexName="postal_vote_application_date_created_idx"/>
+            <dropIndex tableName="proxy_vote_application" indexName="proxy_vote_application_date_created_idx"/>
+        </rollback>
+
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -23,3 +23,5 @@ databaseChangeLog:
       file: /db/changelog/create/0011_EIP1-6891_modify_rejection_reasons.xml
   - include:
       file: /db/changelog/create/0012_EIP1-6836_modify_remaining_rejection_reasons.xml
+  - include:
+      file: /db/changelog/create/0013_EIP1-7400_add_index_on_date_created.xml


### PR DESCRIPTION
Add index on date_created to application tables to fix bug for some EROs. Was previously possibly to exhaust sort buffer with signature data when ERO was across many GSS codes due to query plan used.