### PR TITLE
EIP1-7400 Use two step process to avoid sort buffer issues

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/PostalVoteApplicationRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.emsintegrationapi.database.repository
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
@@ -11,11 +12,21 @@ import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 interface PostalVoteApplicationRepository :
     JpaRepository<PostalVoteApplication, String>,
     JpaSpecificationExecutor<PostalVoteApplication> {
-    fun findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+
+    /**
+     * Find applications with the given IDs. This should only be used when confirmed the application is within
+     * a suitable GSS code and intended for use with the query below.
+     */
+    fun findByApplicationIdIn(applicationIds: List<String>): List<PostalVoteApplication>
+
+    // This custom query ensures we are only sorting over a limited set of data. Across entire application the signature
+    // data causes sort buffer overflow on the database as sorts all data in buffer including base 64 signature data.
+    @Query("select a.applicationId from PostalVoteApplication a where a.applicationDetails.gssCode in :gssCode and a.status = :status order by a.dateCreated asc")
+    fun findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
         gssCode: List<String>,
         status: RecordStatus,
         pageable: Pageable
-    ): List<PostalVoteApplication>
+    ): List<String>
 
     fun findByApplicationIdAndApplicationDetailsGssCodeIn(
         applicationId: String,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
@@ -3,7 +3,9 @@ package uk.gov.dluhc.emsintegrationapi.database.repository
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 
@@ -11,11 +13,21 @@ import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 interface ProxyVoteApplicationRepository :
     JpaRepository<ProxyVoteApplication, String>,
     JpaSpecificationExecutor<ProxyVoteApplication> {
-    fun findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+
+    /**
+     * Find applications with the given IDs. This should only be used when confirmed the application is within
+     * a suitable GSS code and intended for use with the query below.
+     */
+    fun findByApplicationIdIn(applicationIds: List<String>): List<ProxyVoteApplication>
+
+    // This custom query ensures we are only sorting over a limited set of data. Across entire application the signature
+    // data causes sort buffer overflow on the database as sorts all data in buffer including base 64 signature data.
+    @Query("select a.applicationId from ProxyVoteApplication a where a.applicationDetails.gssCode in :gssCode and a.status = :status order by a.dateCreated asc")
+    fun findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
         gssCode: List<String>,
         status: RecordStatus,
         pageable: Pageable
-    ): List<ProxyVoteApplication>
+    ): List<String>
 
     fun findByApplicationIdAndApplicationDetailsGssCodeIn(
         applicationId: String,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/ProxyVoteApplicationRepository.kt
@@ -5,7 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
-import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationService.kt
@@ -31,12 +31,14 @@ class PostalVoteApplicationService(
         val gssCodes = getGssCodes(certificateSerialNumber)
         val numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
         logger.info("Fetching $pageSize applications from DB for Serial No=$certificateSerialNumber and gss codes = $gssCodes")
-        val postalApplicationsList =
-            postalVoteApplicationRepository.findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
-                gssCodes,
-                RecordStatus.RECEIVED,
-                Pageable.ofSize(numberOfRecordsToFetch)
-            )
+        val postalApplicationIds = postalVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+            gssCodes,
+            RecordStatus.RECEIVED,
+            Pageable.ofSize(numberOfRecordsToFetch)
+        )
+        val postalApplications = postalVoteApplicationRepository.findByApplicationIdIn(postalApplicationIds)
+        val postalApplicationsList = postalApplicationIds.map { id -> postalApplications.find { it.applicationId == id }!! }
+
         val actualPageSize = postalApplicationsList.size
         logger.info("The actual number of records fetched is $actualPageSize")
         return PostalVoteApplications(actualPageSize, postalVoteMapper.mapFromEntities(postalApplicationsList))

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationService.kt
@@ -32,12 +32,13 @@ class ProxyVoteApplicationService(
         val gssCodes = retrieveGssCodeService.getGssCodeFromCertificateSerial(certificateSerialNumber)
         val numberOfRecordsToFetch = pageSize ?: apiProperties.defaultPageSize
         logger.info("Fetching $pageSize proxy vote applications from DB for Serial No=$certificateSerialNumber and gss codes = $gssCodes")
-        val proxyApplicationsList =
-            proxyVoteApplicationRepository.findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
-                gssCodes,
-                RecordStatus.RECEIVED,
-                Pageable.ofSize(numberOfRecordsToFetch)
-            )
+        val proxyApplicationIds = proxyVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+            gssCodes,
+            RecordStatus.RECEIVED,
+            Pageable.ofSize(numberOfRecordsToFetch)
+        )
+        val proxyApplications = proxyVoteApplicationRepository.findByApplicationIdIn(proxyApplicationIds)
+        val proxyApplicationsList = proxyApplicationIds.map { id -> proxyApplications.find { it.applicationId == id }!! }
         val actualPageSize = proxyApplicationsList.size
         logger.info("The actual number of records fetched is $actualPageSize")
         return ProxyVoteApplications(actualPageSize, proxyVoteMapper.mapFromEntities(proxyApplicationsList))

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/PostalVoteApplicationServiceTest.kt
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.given
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.*
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration.QueueName.DELETED_POSTAL_APPLICATION_QUEUE
@@ -121,16 +117,18 @@ internal class PostalVoteApplicationServiceTest {
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj {
                 buildPostalVoteApplication(applicationId = it.toString())
             }.toList()
+        val savedApplicationIds = savedApplications.map { it.applicationId }.toList()
         val mockPostalVotes =
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj { mock<PostalVote>() }.toList()
 
         given(
-            postalVoteApplicationRepository.findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+            postalVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
                 GSS_CODES,
                 RecordStatus.RECEIVED,
                 Pageable.ofSize(pageSizeRequested ?: DEFAULT_PAGE_SIZE)
             )
-        ).willReturn(savedApplications)
+        ).willReturn(savedApplicationIds)
+        given { postalVoteApplicationRepository.findByApplicationIdIn(savedApplicationIds) }.willReturn(savedApplications)
         given { postalVoteMapper.mapFromEntities(savedApplications) }.willReturn(mockPostalVotes)
 
         val postalVoteApplications =

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
@@ -10,11 +10,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.given
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.*
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration
@@ -116,16 +112,18 @@ internal class ProxyVoteApplicationServiceTest {
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj {
                 buildProxyVoteApplication(applicationId = it.toString())
             }.toList()
+        val savedApplicationIds = savedApplications.map { it.applicationId }.toList()
         val mockProxyVotes =
             IntStream.rangeClosed(1, numberOfRecordsToBeReturned).mapToObj { mock<ProxyVote>() }.toList()
 
         given(
-            proxyVoteApplicationRepository.findByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
+            proxyVoteApplicationRepository.findApplicationIdsByApplicationDetailsGssCodeInAndStatusOrderByDateCreated(
                 GSS_CODES,
                 RecordStatus.RECEIVED,
                 Pageable.ofSize(pageSizeRequested ?: DEFAULT_PAGE_SIZE)
             )
-        ).willReturn(savedApplications)
+        ).willReturn(savedApplicationIds)
+        given { proxyVoteApplicationRepository.findByApplicationIdIn(savedApplicationIds) }.willReturn(savedApplications)
         given { proxyVoteMapper.mapFromEntities(savedApplications) }.willReturn(mockProxyVotes)
 
         val proxyVoteApplications =

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/ProxyVoteApplicationServiceTest.kt
@@ -10,7 +10,11 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.*
+import org.mockito.kotlin.given
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.data.domain.Pageable
 import uk.gov.dluhc.emsintegrationapi.config.ApiProperties
 import uk.gov.dluhc.emsintegrationapi.config.QueueConfiguration


### PR DESCRIPTION
Issue still being caused when sort buffer used as full application loaded into memory including signature data. Sorting to find suitable applications returning only application ID and then full applications unsorted as a two step process should avoid this as only sorting smaller set of data and then fetching larger data set without any sorting