### PR TITLE
EROPSPT-186: Increase the limit from 250 characters to 500 characters for signatureWaivedReasons

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ApplicationDetails.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ApplicationDetails.kt
@@ -28,7 +28,7 @@ class ApplicationDetails(
 
     val signatureWaived: Boolean?,
 
-    @field:Size(max = 250)
+    @field:Size(max = 500)
     val signatureWaivedReason: String?,
 
     var emsStatus: EmsStatus?,

--- a/src/main/resources/db/changelog/create/0017_EROPSPT-186_increase_signature_waived_reason_max_length.xml
+++ b/src/main/resources/db/changelog/create/0017_EROPSPT-186_increase_signature_waived_reason_max_length.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="0017_EROPSPT-186_increase_signature_waived_reason_max_length" author="kirsty.land@softwire.com" context="ddl">
+        <modifyDataType tableName="postal_vote_application" columnName="signature_waived_reason" newDataType="varchar(500)"/>
+        <modifyDataType tableName="proxy_vote_application" columnName="signature_waived_reason" newDataType="varchar(500)"/>
+
+        <rollback>
+            <modifyDataType tableName="postal_vote_application" columnName="signature_waived_reason" newDataType="varchar(250)"/>
+            <modifyDataType tableName="proxy_vote_application" columnName="signature_waived_reason" newDataType="varchar(250)"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -31,3 +31,5 @@ databaseChangeLog:
       file: /db/changelog/create/0015_EIP1-6984_modify_rejection_notes_structure.xml
   - include:
       file: /db/changelog/create/0016_EIP1-7659_update_signatures_to_be_mediumtext.xml
+  - include:
+      file: /db/changelog/create/0017_EROPSPT-186_increase_signature_waived_reason_max_length.xml

--- a/src/main/resources/openapi/sqs/Models/ApplicationDetails.yaml
+++ b/src/main/resources/openapi/sqs/Models/ApplicationDetails.yaml
@@ -59,7 +59,7 @@ properties:
       Where an Elector has been granted a signature waiver. If 'true', then no signature will be provided and a signatureWaivedReason will be supplied.
   signatureWaivedReason:
     type: string
-    maxLength: 250
+    maxLength: 500
     default: false
     description: |
       Where an Elector has been granted a signature waiver, this field will contain a descriptin of the reason for the waiver.

--- a/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/postal-vote-application-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Approved/Rejected Postal Application SQS Message
-  version: 1.2.0
+  version: 1.2.1
   description: |-
     Approved/Rejected Postal application API SQS Message Types for EROP
 

--- a/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/proxy-vote-application-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Approved/Rejected Proxy Application SQS Message
-  version: 1.2.1
+  version: 1.2.2
   description: |-
     Approved/Rejected Proxy application API SQS Message Types for EROP
 

--- a/src/test/resources/features/save-postal-vote-application.feature
+++ b/src/test/resources/features/save-postal-vote-application.feature
@@ -18,6 +18,7 @@ Feature: System process an approved/rejected postal vote application message
       | PostalApplicationId      | WaiverReason |
       | 502cf250036469154b4f85fa | Disabled     |
       | 502cf250036469154b4f85fb | Other        |
+      | 502cf250036469154b4f85fc | I have a disability that prevents me from signing or uploading my signature: Visually impaired and wants to use the full 250 character allowance. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vehicula hendrerit eros consequat sagittis. Curabitur eget nisi ac felis tincidunt ultrices. Duis imperdiet tempus. |
 
   Scenario Outline: The system does not allow two different postal applications having same id and a different ems electoral id
     Given a postal vote application with the application id "<PostalApplicationId>" and electoral id "<EmsElectoralId>" exists

--- a/src/test/resources/features/save-proxy-vote-application.feature
+++ b/src/test/resources/features/save-proxy-vote-application.feature
@@ -18,6 +18,7 @@ Feature: System process an approved/rejected proxy vote application message
       | ProxyApplicationId       | WaiverReason |
       | 502cf250036469154b4f85fa | Disabled     |
       | 502cf250036469154b4f85fb | Other        |
+      | 502cf250036469154b4f85fc | I have a disability that prevents me from signing or uploading my signature: Visually impaired and wants to use the full 250 character allowance. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vehicula hendrerit eros consequat sagittis. Curabitur eget nisi ac felis tincidunt ultrices. Duis imperdiet tempus. |
 
   Scenario Outline: The system does not allow two different proxy applications having same id and a different ems electoral id
     Given a proxy vote application with the application id "<ProxyApplicationId>" and electoral id "<EmsElectoralId>" exists


### PR DESCRIPTION
Currently there is a mismatch between EMS integration api and the rest of the system on the maximum length of a signature waived reason:

- The max elector facing length is 250 characters
- Some explanatory characters are then added to the beginning of this by IER
- The rest of EROP assumes these explanatory characters are there, taking the max length up to 327
- The specification for connecting EMS's says there will be at most 500 characters that they receive
- BUT the EMS integration API specification and database are configured to allow only 250 characters.

Therefore some messages being received by EMS integration API are too long and end up on the DLQ so never get downloaded by EMSes.

Bumping this up to 500 characters makes everything consistent and should fix the bug.