### PR TITLE
EIP1-11115: use request id as correlation id for initiate reg check messages

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/mapper/InitiateRegisterCheckMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/mapper/InitiateRegisterCheckMapper.kt
@@ -16,7 +16,7 @@ import java.util.UUID
 )
 interface InitiateRegisterCheckMapper {
 
-    @Mapping(target = "correlationId", expression = "java(UUID.randomUUID())")
+    @Mapping(target = "correlationId", source = "sourceCorrelationId")
     @Mapping(target = "createdBy", source = "requestedBy")
     fun initiateCheckMessageToPendingRegisterCheckDto(initiateRegisterCheckMessage: InitiateRegisterCheckMessage): PendingRegisterCheckDto
 }

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/mapper/InitiateRegisterCheckMapperTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/mapper/InitiateRegisterCheckMapperTest.kt
@@ -16,7 +16,6 @@ import uk.gov.dluhc.emsintegrationapi.dto.PersonalDetailDto
 import uk.gov.dluhc.emsintegrationapi.mapper.SourceTypeMapper
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.messaging.buildInitiateRegisterCheckMessage
 import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType
-import java.util.UUID.randomUUID
 import uk.gov.dluhc.emsintegrationapi.dto.SourceType as DtoSourceType
 
 @ExtendWith(MockitoExtension::class)
@@ -35,11 +34,11 @@ internal class InitiateRegisterCheckMapperTest {
         given(sourceTypeMapper.fromSqsToDtoEnum(any())).willReturn(DtoSourceType.VOTER_CARD)
 
         val expected = PendingRegisterCheckDto(
-            correlationId = randomUUID(),
+            correlationId = message.sourceCorrelationId,
             sourceType = DtoSourceType.VOTER_CARD,
             sourceReference = message.sourceReference,
             sourceCorrelationId = message.sourceCorrelationId,
-            createdBy = "system",
+            createdBy = message.requestedBy,
             gssCode = message.gssCode,
             personalDetail = with(message.personalDetail) {
                 PersonalDetailDto(
@@ -71,7 +70,6 @@ internal class InitiateRegisterCheckMapperTest {
         // Then
         assertThat(actual)
             .usingRecursiveComparison()
-            .ignoringFields("correlationId", "createdBy")
             .isEqualTo(expected)
         assertThat(actual.correlationId).isNotNull
         assertThat(actual.createdAt).isNull()


### PR DESCRIPTION
use request id as correlation id for initiate reg check messages