### PR TITLE
EROPSPT-710: Fix tomcat version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,11 +29,12 @@ extra["springCloudVersion"] = "3.2.1"
 extra["springCloudAwsVersion"] = "3.2.1"
 extra["junitJupiterVersion"] = "5.10.5"
 
-// Forcing 4.1.133 version of netty to patch vulnerabilities, under EROPSPT-710.
-// When we upgrade to spring v4 we should check if spring pulls in newer versions of netty.
+// Forcing 4.1.133 version of netty and 10.1.55 version of tomcat to patch vulnerabilities, under EROPSPT-710.
+// When we upgrade to spring v4 we should check if spring pulls in newer versions of netty and tomcat.
 // If so, this override should be removed.
 // TODO EROPSPT-603
 extra["netty.version"] = "4.1.133.Final"
+extra["tomcat.version"] = "10.1.55"
 
 allOpen {
     annotations("jakarta.persistence.Entity", "jakarta.persistence.MappedSuperclass", "jakarta.persistence.Embedabble")


### PR DESCRIPTION
## Describe your changes
- Fixing tomcat version to 10.1.55, vulnerability (v10.1.54) brought in by Springboot v3.5.14
- Fixes:* CVE-2026-43515 * CVE-2026-43514 * CVE-2026-43513 * CVE-2026-41293 * CVE-2026-41284 * CVE-2026-43512 * CVE-2026-42498
 
## Issue ticket number and link

https://mhclgdigital.atlassian.net/browse/EROPSPT-710

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [x] I double checked that ACs on the ticket are met by this code update
- ❌ I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- ❌ I have updated the relevant yml versions
- ❌ I have added tests to new code and updated existing tests where needed
- ❌ I have checked complies with [security policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/security-policy.md) and [data protection policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/data-protection-policy.md)
- ❌ Code reviewer has verified during code review the relevant controls and practices for the two policies mentioned above
- ❌ I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
