### PR TITLE
EIP1-13780: Handle DataIntegrity exception for SQS duplicates

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/RegisterCheckRepository.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/repository/RegisterCheckRepository.kt
@@ -20,6 +20,8 @@ interface RegisterCheckRepository :
 
     fun findBySourceReference(sourceReference: String): List<RegisterCheck>
 
+    fun findBySourceCorrelationId(sourceCorrelationId: UUID): RegisterCheck?
+
     @Query(
         """
         SELECT 

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/exception/RegisterCheckSaveDataIntegrityException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/exception/RegisterCheckSaveDataIntegrityException.kt
@@ -3,4 +3,4 @@ package uk.gov.dluhc.emsintegrationapi.exception
 import java.util.UUID
 
 class RegisterCheckSaveDataIntegrityException(sourceCorrelationId: UUID) :
-        RuntimeException("DataIntegrityViolationException found when trying to save register check with source correlation id: [$sourceCorrelationId]")
+    RuntimeException("DataIntegrityViolationException found when trying to save register check with source correlation id: [$sourceCorrelationId]")

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/exception/RegisterCheckSaveDataIntegrityException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/exception/RegisterCheckSaveDataIntegrityException.kt
@@ -1,0 +1,6 @@
+package uk.gov.dluhc.emsintegrationapi.exception
+
+import java.util.UUID
+
+class RegisterCheckSaveDataIntegrityException(sourceCorrelationId: UUID) :
+        RuntimeException("DataIntegrityViolationException found when trying to save register check with source correlation id: [$sourceCorrelationId]")

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -29,8 +29,8 @@ class InitiateRegisterCheckMessageListener(
         with(payload) {
             logger.info {
                 "New InitiateRegisterCheckMessage received with " +
-                        "sourceReference: $sourceReference and " +
-                        "sourceCorrelationId: $sourceCorrelationId"
+                    "sourceReference: $sourceReference and " +
+                    "sourceCorrelationId: $sourceCorrelationId"
             }
 
             val pendingRegisterCheckDto = mapper.initiateCheckMessageToPendingRegisterCheckDto(this)

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -6,6 +6,7 @@ import mu.KotlinLogging
 import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
+import uk.gov.dluhc.emsintegrationapi.exception.RegisterCheckSaveDataIntegrityException
 import uk.gov.dluhc.emsintegrationapi.messaging.mapper.InitiateRegisterCheckMapper
 import uk.gov.dluhc.emsintegrationapi.service.RegisterCheckService
 import uk.gov.dluhc.messagingsupport.MessageListener
@@ -28,15 +29,16 @@ class InitiateRegisterCheckMessageListener(
         with(payload) {
             logger.info {
                 "New InitiateRegisterCheckMessage received with " +
-                    "sourceReference: $sourceReference and " +
-                    "sourceCorrelationId: $sourceCorrelationId"
+                        "sourceReference: $sourceReference and " +
+                        "sourceCorrelationId: $sourceCorrelationId"
             }
 
             val pendingRegisterCheckDto = mapper.initiateCheckMessageToPendingRegisterCheckDto(this)
             try {
                 registerCheckService.save(pendingRegisterCheckDto)
             } catch (ex: DataIntegrityViolationException) {
-                val registerCheck = registerCheckService.getRegisterCheckOrNull(pendingRegisterCheckDto.sourceCorrelationId)
+                val registerCheck =
+                    registerCheckService.getRegisterCheckOrNull(pendingRegisterCheckDto.sourceCorrelationId)
                 if (registerCheck !== null) {
                     logger.warn(
                         "Attempted to initiate register check with source correlation ID [${pendingRegisterCheckDto.sourceCorrelationId}] for application [${pendingRegisterCheckDto.sourceReference}]. Request failed due to duplicate register check found."
@@ -45,7 +47,7 @@ class InitiateRegisterCheckMessageListener(
                     return
                 }
 
-                throw ex
+                throw RegisterCheckSaveDataIntegrityException(pendingRegisterCheckDto.sourceCorrelationId).initCause(ex)
             }
         }
     }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -3,6 +3,7 @@ package uk.gov.dluhc.emsintegrationapi.messaging
 import io.awspring.cloud.sqs.annotation.SqsListener
 import jakarta.validation.Valid
 import mu.KotlinLogging
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.messaging.handler.annotation.Payload
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.emsintegrationapi.messaging.mapper.InitiateRegisterCheckMapper
@@ -27,12 +28,24 @@ class InitiateRegisterCheckMessageListener(
         with(payload) {
             logger.info {
                 "New InitiateRegisterCheckMessage received with " +
-                    "sourceReference: $sourceReference and " +
-                    "sourceCorrelationId: $sourceCorrelationId"
+                        "sourceReference: $sourceReference and " +
+                        "sourceCorrelationId: $sourceCorrelationId"
             }
 
             val pendingRegisterCheckDto = mapper.initiateCheckMessageToPendingRegisterCheckDto(this)
-            registerCheckService.save(pendingRegisterCheckDto)
+            try {
+                registerCheckService.save(pendingRegisterCheckDto)
+            } catch (ex: DataIntegrityViolationException) {
+                if (ex.message?.contains("register_check.register_check_app_correlation_id_unique_idx") == true) {
+                    logger.warn(
+                        "Attempted to initiate register check with correlation ID [${pendingRegisterCheckDto.sourceCorrelationId}] for application [${pendingRegisterCheckDto.sourceReference}]. Request failed due to duplicate register check found."
+                    )
+
+                    return
+                }
+
+                throw ex
+            }
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -36,9 +36,10 @@ class InitiateRegisterCheckMessageListener(
             try {
                 registerCheckService.save(pendingRegisterCheckDto)
             } catch (ex: DataIntegrityViolationException) {
-                if (ex.message?.contains("register_check.register_check_app_correlation_id_unique_idx") == true) {
+                val registerCheck = registerCheckService.getRegisterCheckOrNull(pendingRegisterCheckDto.sourceCorrelationId)
+                if (registerCheck !== null) {
                     logger.warn(
-                        "Attempted to initiate register check with correlation ID [${pendingRegisterCheckDto.sourceCorrelationId}] for application [${pendingRegisterCheckDto.sourceReference}]. Request failed due to duplicate register check found."
+                        "Attempted to initiate register check with source correlation ID [${pendingRegisterCheckDto.sourceCorrelationId}] for application [${pendingRegisterCheckDto.sourceReference}]. Request failed due to duplicate register check found."
                     )
 
                     return

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -28,8 +28,8 @@ class InitiateRegisterCheckMessageListener(
         with(payload) {
             logger.info {
                 "New InitiateRegisterCheckMessage received with " +
-                        "sourceReference: $sourceReference and " +
-                        "sourceCorrelationId: $sourceCorrelationId"
+                    "sourceReference: $sourceReference and " +
+                    "sourceCorrelationId: $sourceCorrelationId"
             }
 
             val pendingRegisterCheckDto = mapper.initiateCheckMessageToPendingRegisterCheckDto(this)

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/RegisterCheckService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/service/RegisterCheckService.kt
@@ -90,6 +90,11 @@ class RegisterCheckService(
         }
     }
 
+    @Transactional
+    fun getRegisterCheckOrNull(
+        sourceCorrelationId: UUID,
+    ): RegisterCheck? = registerCheckRepository.findBySourceCorrelationId(sourceCorrelationId)
+
     fun sendConfirmRegisterCheckResultMessage(registerCheck: RegisterCheck) {
         with(registerCheckResultMessageMapper.fromRegisterCheckEntityToRegisterCheckResultMessage(registerCheck)) {
             logger.info {

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
@@ -104,10 +104,12 @@ internal class InitiateRegisterCheckMessageListenerIntegrationTest : Integration
 
         // Then
         await().atMost(2, TimeUnit.SECONDS).untilAsserted {
-            Assertions.assertThat(TestLogAppender.hasLog(
-                "Attempted to initiate register check with correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",
-                Level.WARN,
-            )).isTrue()
+            Assertions.assertThat(
+                TestLogAppender.hasLog(
+                    "Attempted to initiate register check with correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",
+                    Level.WARN,
+                )
+            ).isTrue()
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
@@ -103,7 +103,7 @@ internal class InitiateRegisterCheckMessageListenerIntegrationTest : Integration
         sqsMessagingTemplate.send(initiateApplicantRegisterCheckQueueName, message)
 
         // Then
-        await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+        await().atMost(3, TimeUnit.SECONDS).untilAsserted {
             Assertions.assertThat(
                 TestLogAppender.hasLog(
                     "Attempted to initiate register check with correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.dluhc.emsintegrationapi.messaging
 
+import ch.qos.logback.classic.Level
 import jakarta.persistence.criteria.CriteriaBuilder
 import jakarta.persistence.criteria.CriteriaQuery
 import jakarta.persistence.criteria.Root
@@ -13,6 +14,7 @@ import uk.gov.dluhc.emsintegrationapi.database.entity.Address
 import uk.gov.dluhc.emsintegrationapi.database.entity.CheckStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.PersonalDetail
 import uk.gov.dluhc.emsintegrationapi.database.entity.RegisterCheck
+import uk.gov.dluhc.emsintegrationapi.testsupport.TestLogAppender
 import uk.gov.dluhc.emsintegrationapi.testsupport.assertj.assertions.entity.RegisterCheckAssert
 import uk.gov.dluhc.emsintegrationapi.testsupport.testdata.messaging.buildInitiateRegisterCheckMessage
 import uk.gov.dluhc.registercheckerapi.messaging.models.InitiateRegisterCheckMessage
@@ -77,6 +79,35 @@ internal class InitiateRegisterCheckMessageListenerIntegrationTest : Integration
 
             stopWatch.stop()
             logger.info("completed assertions in $stopWatch")
+        }
+    }
+
+    @Test
+    fun `should ignore duplicate register check message`() {
+        // Given
+        val message = buildInitiateRegisterCheckMessage()
+
+        // When
+        sqsMessagingTemplate.send(initiateApplicantRegisterCheckQueueName, message)
+
+        val stopWatch = StopWatch.createStarted()
+        await().atMost(5, TimeUnit.SECONDS).untilAsserted {
+            val actualRegisterCheckJpaEntity = getActualRegisterCheckJpaEntity(message)
+            Assertions.assertThat(actualRegisterCheckJpaEntity).hasSize(1)
+
+            Assertions.assertThat(actualRegisterCheckJpaEntity.first().sourceCorrelationId).isEqualTo(message.sourceCorrelationId)
+            stopWatch.stop()
+            logger.info("completed assertions in $stopWatch")
+        }
+
+        sqsMessagingTemplate.send(initiateApplicantRegisterCheckQueueName, message)
+
+        // Then
+        await().atMost(2, TimeUnit.SECONDS).untilAsserted {
+            Assertions.assertThat(TestLogAppender.hasLog(
+                "Attempted to initiate register check with correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",
+                Level.WARN,
+            )).isTrue()
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/messaging/InitiateRegisterCheckMessageListenerIntegrationTest.kt
@@ -106,7 +106,7 @@ internal class InitiateRegisterCheckMessageListenerIntegrationTest : Integration
         await().atMost(3, TimeUnit.SECONDS).untilAsserted {
             Assertions.assertThat(
                 TestLogAppender.hasLog(
-                    "Attempted to initiate register check with correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",
+                    "Attempted to initiate register check with source correlation ID [${message.sourceCorrelationId}] for application [${message.sourceReference}]. Request failed due to duplicate register check found.",
                     Level.WARN,
                 )
             ).isTrue()

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/RegisterCheckServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/service/RegisterCheckServiceTest.kt
@@ -108,6 +108,20 @@ internal class RegisterCheckServiceTest {
     }
 
     @Nested
+    inner class GetRegisterCheckOrNull {
+        @Test
+        fun `should get register check ID if one exists with matching source correlation id`() {
+            // Given
+            val uuid = randomUUID()
+            // When
+            registerCheckService.getRegisterCheckOrNull(uuid)
+
+            // Then
+            verify(registerCheckRepository).findBySourceCorrelationId(uuid)
+        }
+    }
+
+    @Nested
     inner class GetPendingRegisterChecks {
 
         @Test


### PR DESCRIPTION
## Describe your changes

If duplicate SQS messages are processed by the listener for `InitiateRegisterCheckMessage`, the save to the DB fails since there is a uniqueness constraint on the `sourceCorrelationId` (which matches up to the register check ID within the Apps API). Catch the `DataIntegrityViolationException` if the exception was caused by this constraint failing and `WARN`, throwing otherwise.

## Issue ticket number and link

https://mhclgdigital.atlassian.net/browse/EIP1-13780

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [x] I double checked that ACs on the ticket are met by this code update
- ❌ I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- ❌ I have updated the relevant yml versions
- [x] I have added tests to new code and updated existing tests where needed
- [x] I have checked complies with [security policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/security-policy.md) and [data protection policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/data-protection-policy.md)
- [ ] Code reviewer has verified during code review the relevant controls and practices for the two policies mentioned above
- ❌ I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
