### PR TITLE
EROPSPT-717: Make retention status nullable and remove fields from entities

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/CommonEnums.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/CommonEnums.kt
@@ -7,11 +7,6 @@ enum class SourceSystem {
     EROP
 }
 
-enum class RetentionStatus {
-    REMOVE,
-    RETAIN,
-}
-
 enum class RecordStatus {
     RECEIVED,
     DELETED,

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/PostalVoteApplication.kt
@@ -39,11 +39,6 @@ class PostalVoteApplication(
     @Embedded
     var postalVoteDetails: PostalVoteDetails? = null,
 
-    var removalDateTime: Instant? = null,
-
-    @Enumerated(EnumType.STRING)
-    var retentionStatus: RetentionStatus,
-
     @CreatedDate
     var dateCreated: Instant? = null,
 

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/database/entity/ProxyVoteApplication.kt
@@ -34,11 +34,6 @@ class ProxyVoteApplication(
     @Embedded
     val proxyVoteDetails: ProxyVoteDetails,
 
-    var removalDateTime: Instant? = null,
-
-    @Enumerated(EnumType.STRING)
-    var retentionStatus: RetentionStatus,
-
     @CreatedDate
     var dateCreated: Instant? = null,
 

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/PostalVoteApplicationMessageMapper.kt
@@ -3,7 +3,6 @@ package uk.gov.dluhc.emsintegrationapi.mapper
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
-import uk.gov.dluhc.emsintegrationapi.database.entity.RetentionStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.SourceSystem
 import uk.gov.dluhc.emsintegrationapi.messaging.models.PostalVoteApplicationMessage
 import uk.gov.dluhc.emsintegrationapi.database.entity.RejectedReasonItem as RejectedReasonItemEntity
@@ -31,7 +30,6 @@ class PostalVoteApplicationMessageMapper(
                     it.primaryElectorDetails,
                 ),
                 createdBy = SourceSystem.POSTAL,
-                retentionStatus = RetentionStatus.RETAIN,
                 status = RecordStatus.RECEIVED,
                 englishRejectionNotes = it.postalVoteDetails?.rejectedReasons?.englishReason?.notes,
                 englishRejectedReasonItems = it.postalVoteDetails?.rejectedReasons?.englishReason?.reasonList

--- a/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/emsintegrationapi/mapper/ProxyVoteApplicationMessageMapper.kt
@@ -3,7 +3,6 @@ package uk.gov.dluhc.emsintegrationapi.mapper
 import org.springframework.stereotype.Component
 import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
-import uk.gov.dluhc.emsintegrationapi.database.entity.RetentionStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.SourceSystem
 import uk.gov.dluhc.emsintegrationapi.messaging.models.ProxyVoteApplicationMessage
 import uk.gov.dluhc.emsintegrationapi.database.entity.RejectedReasonItem as RejectedReasonItemEntity
@@ -26,7 +25,6 @@ class ProxyVoteApplicationMessageMapper(
                 ),
                 proxyVoteDetails = proxyVoteDetailsMapper.mapToProxyVoteDetailsEntity(it.proxyVoteDetails),
                 createdBy = SourceSystem.PROXY,
-                retentionStatus = RetentionStatus.RETAIN,
                 status = RecordStatus.RECEIVED,
                 englishRejectionNotes = it.proxyVoteDetails.rejectedReasons?.englishReason?.notes,
                 englishRejectedReasonItems = it.proxyVoteDetails.rejectedReasons?.englishReason?.reasonList

--- a/src/main/resources/db/changelog/create/0042_EROPSPT-717_retention_status_nullable.xml
+++ b/src/main/resources/db/changelog/create/0042_EROPSPT-717_retention_status_nullable.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="alex.yip@softwire.com" id="0042_EROPSPT-717_retention_status_nullable" context="ddl">
+        <modifyDataType tableName="postal_vote_application" columnName="retention_status" newDataType="varchar(20)"/>
+        <modifyDataType tableName="proxy_vote_application" columnName="retention_status" newDataType="varchar(20)"/>
+
+        <rollback>
+            <modifyDataType tableName="postal_vote_application" columnName="retention_status"
+                            newDataType="varchar(20) NOT NULL"/>
+            <modifyDataType tableName="proxy_vote_application" columnName="retention_status"
+                            newDataType="varchar(20) NOT NULL"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -83,3 +83,5 @@ databaseChangeLog:
       file: /db/changelog/create/0040_EROPSPT-538_add_application_reference_to_register_check_table.xml
   - include:
       file: /db/changelog/create/0041_EROPSPT-566_add_application_reference_to_vote_application_tables.xml
+  - include:
+      file: /db/changelog/create/0042_EROPSPT-717_retention_status_nullable.xml

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/PostalVoteApplicationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/PostalVoteApplicationBuilder.kt
@@ -7,7 +7,6 @@ import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteApplicationPrima
 import uk.gov.dluhc.emsintegrationapi.database.entity.PostalVoteDetails
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.RejectedReasonItem
-import uk.gov.dluhc.emsintegrationapi.database.entity.RetentionStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.SourceSystem
 import uk.gov.dluhc.emsintegrationapi.messaging.models.PostalVoteApplicationMessage
 import java.time.Instant
@@ -23,8 +22,6 @@ fun buildPostalVoteApplication(
     applicantDetails: ApplicantDetails = buildApplicantDetailsEntity(),
     postalVoteDetails: PostalVoteDetails? = buildPostalVoteDetailsEntity(),
     primaryElectorDetails: PostalVoteApplicationPrimaryElectorDetails? = null,
-    removalDateTime: Instant? = null,
-    retentionStatus: RetentionStatus = RetentionStatus.RETAIN,
     createdBy: SourceSystem = SourceSystem.POSTAL,
     dateUpdated: Instant? = null,
     updatedBy: SourceSystem? = null,
@@ -39,8 +36,6 @@ fun buildPostalVoteApplication(
     applicantDetails = applicantDetails,
     postalVoteDetails = postalVoteDetails,
     primaryElectorDetails = primaryElectorDetails,
-    removalDateTime = removalDateTime,
-    retentionStatus = retentionStatus,
     createdBy = createdBy,
     dateUpdated = dateUpdated,
     updatedBy = updatedBy,

--- a/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/ProxyVoteApplicationBuilder.kt
+++ b/src/test/kotlin/uk/gov/dluhc/emsintegrationapi/testsupport/testdata/ProxyVoteApplicationBuilder.kt
@@ -6,7 +6,6 @@ import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteApplication
 import uk.gov.dluhc.emsintegrationapi.database.entity.ProxyVoteDetails
 import uk.gov.dluhc.emsintegrationapi.database.entity.RecordStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.RejectedReasonItem
-import uk.gov.dluhc.emsintegrationapi.database.entity.RetentionStatus
 import uk.gov.dluhc.emsintegrationapi.database.entity.SourceSystem
 import uk.gov.dluhc.emsintegrationapi.messaging.models.ProxyVoteApplicationMessage
 import java.time.Instant
@@ -20,8 +19,6 @@ fun buildProxyVoteApplication(
     applicationDetails: ApplicationDetails = buildApplicationDetailsEntity(),
     applicantDetails: ApplicantDetails = buildApplicantDetailsEntity(),
     proxyVoteDetails: ProxyVoteDetails = buildProxyVoteDetailsEntity(),
-    removalDateTime: Instant? = null,
-    retentionStatus: RetentionStatus = RetentionStatus.RETAIN,
     createdBy: SourceSystem = SourceSystem.POSTAL,
     dateUpdated: Instant? = null,
     updatedBy: SourceSystem? = null,
@@ -35,8 +32,6 @@ fun buildProxyVoteApplication(
     applicationDetails = applicationDetails,
     applicantDetails = applicantDetails,
     proxyVoteDetails = proxyVoteDetails,
-    removalDateTime = removalDateTime,
-    retentionStatus = retentionStatus,
     createdBy = createdBy,
     dateUpdated = dateUpdated,
     updatedBy = updatedBy,


### PR DESCRIPTION
## Describe your changes

These columns aren't used anywhere, so cleaning them up.

I've added the manual script to delete the columns here: https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/932217119/Release+-+EROP+3.65+-+11+06+2026#Pre-release-Instructions

Subsequent PR: https://github.com/communitiesuk/eip-ero-ems-integration-api/pull/211

## Issue ticket number and link

https://mhclgdigital.atlassian.net/browse/EROPSPT-717

## Checklist before requesting a review
Tick all those which are done
Replace check box with ❌ if the step is not relevant for this PR

- [x] I double checked that ACs on the ticket are met by this code update
- [x] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/871694357/Safe+Release+Cheat+Sheet))
- :x: I have updated the relevant yml versions
- [x] I have added tests to new code and updated existing tests where needed
- [x] I have checked complies with [security policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/security-policy.md) and [data protection policy](https://github.com/communitiesuk/eip-ero-applications-api/blob/main/docs/guidelines/data-protection-policy.md)
- [ ] Code reviewer has verified during code review the relevant controls and practices for the two policies mentioned above
- [x] I have documented any release dependencies (e.g. service release order or incompatible versions) in the [Release notes](https://mhclgdigital.atlassian.net/wiki/spaces/ED1/pages/873365661/Release+-+EROP+Version+-+Date+TBC)
    - Can leave tags as tbd until merged
